### PR TITLE
Améliore le menu mobile avec police Fraktur et background visible

### DIFF
--- a/assets/scss/_main-menu-mobile.scss
+++ b/assets/scss/_main-menu-mobile.scss
@@ -1,6 +1,7 @@
 .menu-main-mobile {
   position: fixed;
-  background: var(--highlight-color);
+  background: var(--surface);
+  backdrop-filter: blur(10px);
   top: 0;
   left: 0;
   width: 100%;
@@ -40,19 +41,27 @@
   }
   ul {
     font-size: 2rem;
-    font-family: 'Inter', sans-serif;
+    font-family: var(--font-family-heading);
     text-align: center;
     list-style: none;
     margin: 0;
+    padding: 2rem 0;
     flex: 0;
     li {
       display: block;
       position: relative;
       opacity: 0;
+      margin: 1.2rem 0;
+      padding: 0.5rem 0;
       a {
         display: block;
         position: relative;
-        color: var(--base-color);
+        color: var(--on-surface);
+        font-family: var(--font-family-heading);
+        font-weight: 700;
+        font-size: 2.5rem;
+        padding: 1rem 2rem;
+        line-height: 1.2;
         text-decoration: none;
         &:hover {
           opacity: 0.7;
@@ -60,11 +69,6 @@
       }
       ul.sub-menu {
         font-size: 1.2rem;
-        li {
-          a {
-
-          }
-        }
       }
     }
   }

--- a/assets/scss/style.scss
+++ b/assets/scss/style.scss
@@ -43,6 +43,10 @@
   --border-radius: 12px;
   --border-radius-large: 16px;
   --border-radius-small: 8px;
+
+  /* Mobile menu compatibility variables */
+  --highlight-color: var(--primary);
+  --base-color: var(--on-primary);
 }
 
 .elevation-0 {


### PR DESCRIPTION
- Ajoute les variables CSS manquantes --highlight-color et --base-color
- Remplace le background transparent par var(--surface) avec backdrop-filter
- Utilise la police Fraktur (var(--font-family-heading)) pour la cohérence
- Augmente la taille de police à 2.5rem pour une meilleure visibilité
- Améliore l'espacement avec des marges et padding optimisés
- Corrige les erreurs de lint CSS (rulesets vides)

Ces changements assurent un menu mobile lisible et stylé par défaut.